### PR TITLE
feat: [BREAKING_CHANGE] support class based async controllers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,12 +210,21 @@ You can also use `async/await` in controller:
 
 `app/io/controller/chat.js`
 ```js
+// defined as class methods
 module.exports = app => {
-  return async function() {
-    const message = this.args[0];
-    console.log(message);
-    await this.socket.emit('res', `Hi! I've got your message: ${message}`);
-  };
+  class Controller extends app.Controller {
+    async ping() {
+      const message = this.ctx.args[0];
+      await this.ctx.socket.emit('res', `Hi! I've got your message: ${message}`);
+    }
+  }
+  return Controller
+};
+
+// or normal functions
+exports.ping = async function() {
+  const message = this.args[0];
+  await this.socket.emit('res', `Hi! I've got your message: ${message}`);
 };
 ```
 
@@ -223,7 +232,7 @@ next, config the router at `app/router.js`
 ```js
 module.exports = app => {
   // or app.io.of('/')
-  app.io.route('chat', app.io.controllers.chat);
+  app.io.route('chat', app.io.controllers.chat.ping);
 };
 ```
 

--- a/README.zh_CN.md
+++ b/README.zh_CN.md
@@ -209,12 +209,21 @@ module.exports = app => {
 
 `app/io/controller/chat.js`
 ```js
+// defined as class methods
 module.exports = app => {
-  return async function() {
-    const message = this.args[0];
-    console.log(message);
-    await this.socket.emit('res', `Hi! I've got your message: ${message}`);
-  };
+  class Controller extends app.Controller {
+    async ping() {
+      const message = this.ctx.args[0];
+      await this.ctx.socket.emit('res', `Hi! I've got your message: ${message}`);
+    }
+  }
+  return Controller
+};
+
+// or normal functions
+exports.ping = async function() {
+  const message = this.args[0];
+  await this.socket.emit('res', `Hi! I've got your message: ${message}`);
 };
 ```
 
@@ -222,7 +231,7 @@ module.exports = app => {
 ```js
 module.exports = app => {
   // or app.io.of('/')
-  app.io.route('chat', app.io.controllers.chat);
+  app.io.route('chat', app.io.controllers.chat.ping);
 };
 ```
 

--- a/example/app/io/controller/chat.js
+++ b/example/app/io/controller/chat.js
@@ -1,10 +1,13 @@
 'use strict';
 
-module.exports = () => {
-  return function* () {
-    const message = this.args[0];
-    console.log('chat :', message + ' : ' + process.pid);
-    const say = yield this.service.user.say();
-    this.socket.emit('res', say);
-  };
+module.exports = app => {
+  class Controller extends app.Controller {
+    * index() {
+      const message = this.ctx.args[0];
+      console.log('chat :', message + ' : ' + process.pid);
+      const say = yield this.service.user.say();
+      this.ctx.socket.emit('res', say);
+    }
+  }
+  return Controller;
 };

--- a/example/app/router.js
+++ b/example/app/router.js
@@ -2,8 +2,8 @@
 
 module.exports = app => {
   // app.io.of('/')
-  app.io.route('chat', app.io.controllers.chat);
+  app.io.route('chat', app.io.controllers.chat.index);
 
   // app.io.of('/chat')
-  app.io.of('/chat').route('chat', app.io.controllers.chat);
+  app.io.of('/chat').route('chat', app.io.controllers.chat.index);
 };

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -17,10 +17,9 @@ module.exports = app => {
 
   dirs = app.loader.getLoadUnits().map(unit => path.join(unit.path, 'app', 'io', 'controller'));
   app.io.controllers = app.io.controllers || {};
-  new app.loader.FileLoader({
+  app.loader.loadController({
     directory: dirs,
     target: app.io.controllers,
-    inject: app,
-  }).load();
+  });
   debug('[egg-socket.io] app.io.middlewares:', app.io.middlewares);
 };

--- a/test/fixtures/apps/socket.io-async/app/io/controller/chat.js
+++ b/test/fixtures/apps/socket.io-async/app/io/controller/chat.js
@@ -1,7 +1,0 @@
-'use strict';
-
-module.exports = () => {
-  return async function(){
-    await this.socket.emit('res', 'hello');
-  };
-};

--- a/test/fixtures/apps/socket.io-async/app/io/controller/chatAsyncClass.js
+++ b/test/fixtures/apps/socket.io-async/app/io/controller/chatAsyncClass.js
@@ -1,0 +1,14 @@
+'use strict';
+
+module.exports = (app) => {
+  // Note: egg (http) doesn't support this style. Keep it consistent
+  // return async function(){
+  //   await this.socket.emit('res', 'hello');
+  // };
+  class Controller extends app.Controller {
+    async ping() {
+      await this.ctx.socket.emit('res', 'hello');
+    }
+  }
+  return Controller
+};

--- a/test/fixtures/apps/socket.io-async/app/io/controller/chatAsyncObject.js
+++ b/test/fixtures/apps/socket.io-async/app/io/controller/chatAsyncObject.js
@@ -1,0 +1,5 @@
+'use strict';
+
+exports.ping = async function() {
+  await this.socket.emit('res', 'hello');
+};

--- a/test/fixtures/apps/socket.io-async/app/router.js
+++ b/test/fixtures/apps/socket.io-async/app/router.js
@@ -1,5 +1,6 @@
 'use strict';
 
 module.exports = app => {
-  app.io.route('chat', app.io.controllers.chat);
+  app.io.route('chat-async-class', app.io.controllers.chatAsyncClass.ping);
+  app.io.route('chat-async-object', app.io.controllers.chatAsyncObject.ping);
 };

--- a/test/fixtures/apps/socket.io-controller-class/app/io/controller/chat.js
+++ b/test/fixtures/apps/socket.io-controller-class/app/io/controller/chat.js
@@ -1,0 +1,14 @@
+'use strict';
+
+module.exports = (app) => {
+  class Controller extends app.Controller {
+    ping() {
+      this.ctx.socket.emit('res', 'hello');
+    }
+
+    * pingGenerator() {
+      this.ctx.socket.emit('res', 'hello');
+    }
+  }
+  return Controller
+};

--- a/test/fixtures/apps/socket.io-controller-class/app/router.js
+++ b/test/fixtures/apps/socket.io-controller-class/app/router.js
@@ -1,0 +1,6 @@
+'use strict';
+
+module.exports = app => {
+  app.io.route('chat', app.io.controllers.chat.ping);
+  app.io.route('chat-generator', app.io.controllers.chat.pingGenerator);
+};

--- a/test/fixtures/apps/socket.io-controller-class/config/config.default.js
+++ b/test/fixtures/apps/socket.io-controller-class/config/config.default.js
@@ -1,0 +1,5 @@
+'use strict';
+
+exports.io = {};
+
+exports.keys = '123';

--- a/test/fixtures/apps/socket.io-controller-class/package.json
+++ b/test/fixtures/apps/socket.io-controller-class/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "socket.io-controller-class",
+  "version": "0.0.1"
+}

--- a/test/io.test.js
+++ b/test/io.test.js
@@ -41,15 +41,44 @@ describe('test/socketio.test.js', () => {
       });
       app.ready().then(() => {
         const socket = client('', { port: basePort });
-        socket.on('connect', () => socket.emit('chat', ''));
+        let success = 0;
+        socket.on('connect', () => {
+          socket.emit('chat-async-class', '');
+          socket.emit('chat-async-object', '');
+        });
         socket.on('disconnect', () => app.close().then(done, done));
         socket.on('res', msg => {
           assert(msg === 'hello');
-          socket.close();
+          if (++success === 2) {
+            socket.close();
+          }
         });
       });
     });
   }
+
+  it('should controller class works ok', done => {
+    const app = mm.cluster({
+      baseDir: 'apps/socket.io-controller-class',
+      workers: 1,
+      sticky: false,
+    });
+    app.ready().then(() => {
+      const socket = client('', { port: basePort });
+      let success = 0;
+      socket.on('connect', () => {
+        socket.emit('chat', '');
+        socket.emit('chat-generator', '');
+      });
+      socket.on('disconnect', () => app.close().then(done, done));
+      socket.on('res', msg => {
+        assert(msg === 'hello');
+        if (++success === 2) {
+          socket.close();
+        }
+      });
+    });
+  });
 
   it('should single worker works ok', done => {
     const app = mm.cluster({


### PR DESCRIPTION
Closes https://github.com/eggjs/egg/issues/894 and https://github.com/eggjs/egg/issues/1382.
BREAKING CHANGE:
  Use a single async function as module's default export won't be supported.