### PR TITLE
fix: miss 'egg-core' dependency may cause a error

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "debug": "^3.1.0",
     "delegates": "^1.0.0",
+    "egg-core": "^4.3.1",
     "is-type-of": "^1.2.0",
     "koa-compose": "^4.0.0",
     "socket.io": "^2.0.4",


### PR DESCRIPTION
connectionMiddlewareInit 依赖了 egg-core

https://github.com/eggjs/egg-socket.io/blob/master/lib/connectionMiddlewareInit.js#L6

package 缺少这个依赖，使用会报错

```
TypeError: Cannot read property 'middleware' of undefined (uncaughtException throw 2 times on pid:17695)
    at connectionMiddlewares.map.mw (/Users/hacke2/work/project/weex-version/node_modules/_egg-socket.io@4.0.3@egg-socket.io/lib/connectionMiddlewareInit.js:10:67)
    at Array.map (<anonymous>)
    at module.exports (/Users/hacke2/work/project/weex-version/node_modules/_egg-socket.io@4.0.3@egg-socket.io/lib/connectionMiddlewareInit.js:10:49)
    at Array.nsp.use (/Users/hacke2/work/project/weex-version/node_modules/_egg-socket.io@4.0.3@egg-socket.io/lib/io.js:103:7)
    at run (/Users/hacke2/work/project/weex-version/node_modules/_socket.io@2.0.4@socket.io/lib/namespace.js:123:11)
    at Namespace.run (/Users/hacke2/work/project/weex-version/node_modules/_socket.io@2.0.4@socket.io/lib/namespace.js:135:3)
    at Namespace.add (/Users/hacke2/work/project/weex-version/node_modules/_socket.io@2.0.4@socket.io/lib/namespace.js:163:8)
    at Client.connect (/Users/hacke2/work/project/weex-version/node_modules/_socket.io@2.0.4@socket.io/lib/client.js:76:20)
    at Server.onconnection (/Users/hacke2/work/project/weex-version/node_modules/_socket.io@2.0.4@socket.io/lib/index.js:398:10)
    at emitOne (events.js:116:13)

```