### PR TITLE
docs: fix ws engine name

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ exports.io = {
 
 #### uws
 
-If you want to replace the default `us` with [uws](https://github.com/uWebSockets/uWebSockets), you can config like this:
+If you want to replace the default `ws` with [uws](https://github.com/uWebSockets/uWebSockets), you can config like this:
 
 ```js
 exports.io = {


### PR DESCRIPTION
#### uws

> If you want to replace the default `ws` with [uws](https://github.com/uWebSockets/uWebSockets), you can config like this:

```js
exports.io = {
  init: { wsEngine: 'uws' },
};
```

#### ws

```js
exports.io = {
  init: { wsEngine: 'ws' },
};
```

- [#L106](https://github.com/socketio/engine.io/blob/6a16ea119280a02029618544d44eb515f7f2d076/lib/server.js#L106)