### PR TITLE
correct eventName to string if it is accidentally converted to int type

### DIFF
--- a/lib/packetMiddlewareInit.js
+++ b/lib/packetMiddlewareInit.js
@@ -25,7 +25,7 @@ module.exports = (app, socket, packet, next, packetMiddlewares, nsp) => {
     next();
     const eventName = packet[0];
     const routerMap = nsp[RouterConfigSymbol];
-    if (routerMap && routerMap.has(eventName)) {
+    if (routerMap && routerMap.has(eventName.toString())) {
       debug('[egg-socket.io] wait controller finshed!');
       // after controller execute finished, resume middlewares
       await new Promise((resolve, reject) => {


### PR DESCRIPTION
if the eventName is not string, it might the checking of .has in Map will not correct. 
```javascript
if (routerMap && routerMap.has(eventName)) {
}
```

The promise below will not run in this case