### PR TITLE
add custome socket id config(增加自定义socket id配置)

### DIFF
--- a/lib/io.js
+++ b/lib/io.js
@@ -113,6 +113,10 @@ module.exports = app => {
 
   app.on('server', server => {
     app.io.attach(server, config.init);
+    // io engine generate socket id
+    if (config.generateId && is.function(config.generateId)) {
+      app.io.engine.generateId = config.generateId;
+    }
     debug('[egg-socket.io] init ready!');
   });
 };


### PR DESCRIPTION
增加自定义socket id配置， 目前未写成middleware；
使用方式如下:
config.default.js
```
exports.io = {
  init: {},
  namespace: {
    '/': {
      connectionMiddleware: [],
      packetMiddleware: [],
    },
  },
  generateId: (req) => {
     return "custom:id:" + new Date().getTime(); // custom id must be unique
  }
};
```