### PR TITLE
feat: Allow users to re-define new generatorID for Socket Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ exports.io = {
 
 #### uws
 
-**Note:** uws has been deprecated, please find another reliable library instead.
+**Note:** `uws` has been deprecated, please find another reliable library instead.
 
 If you want to replace the default `ws` with [uws](https://github.com/uWebSockets/uWebSockets), you can config like this:
 
@@ -78,6 +78,19 @@ exports.io = {
 read more about init config at: [engine.io](https://github.com/socketio/engine.io/blob/master/README.md#methods-1) .
 
 see [config/config.default.js](config/config.default.js) for more detail.
+
+### generateId
+
+**Note:** This function is left on purpose to override and generate a unique ID according to your own rule:
+
+```js
+exports.io = {
+  generateId: (request) => {
+        // Something like UUID.
+        return 'This should be a random unique ID';
+    }
+};
+```
 
 ## Deployment
 

--- a/README.zh_CN.md
+++ b/README.zh_CN.md
@@ -65,7 +65,7 @@ exports.io = {
 
 #### uws
 
-**注意:** uws 已经被官方弃用，请寻找其他可靠的替代库。
+**注意:** `uws` 已经被官方弃用，请寻找其他可靠的替代库。
 
 如果你想用 [uws](https://github.com/uWebSockets/uWebSockets) 替换掉默认的 `us` , 可以这样配置:
 
@@ -78,6 +78,19 @@ exports.io = {
 更多 init 配置参考： [engine.io](https://github.com/socketio/engine.io/blob/master/README.md#methods-1) .
 
 see [config/config.default.js](config/config.default.js) for more detail.
+
+### generateId
+
+**注意：** 此函数作为接口预留，便于你按照自己的规则为每一个 socket 生成唯一的 ID：
+
+```js
+exports.io = {
+  generateId: (request) => {
+        // Something like UUID.
+        return 'This should be a random unique ID';
+    }
+};
+```
 
 ## 部署
 

--- a/lib/io.js
+++ b/lib/io.js
@@ -113,6 +113,15 @@ module.exports = app => {
 
   app.on('server', server => {
     app.io.attach(server, config.init);
+
+    // Check whether it's a common function, it shouldn't be
+    // an async or generator function, or it will be ignored.
+    if (typeof config.generateId === 'function' &&
+      !is.asyncFunction(config.generateId) &&
+      !is.generatorFunction(config.generateId)) {
+      app.io.engine.generateId = config.generateId;
+    }
+
     debug('[egg-socket.io] init ready!');
   });
 };

--- a/test/fixtures/apps/socket.io-generateId/app/io/controller/generateId.js
+++ b/test/fixtures/apps/socket.io-generateId/app/io/controller/generateId.js
@@ -1,0 +1,10 @@
+'use strict';
+
+module.exports = (app) => {
+  class Controller extends app.Controller {
+    ping() {
+      this.ctx.socket.emit('res', 'hello');
+    }
+  }
+  return Controller
+};

--- a/test/fixtures/apps/socket.io-generateId/app/router.js
+++ b/test/fixtures/apps/socket.io-generateId/app/router.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = app => {
+  app.io.route('generateId', app.io.controller.generateId.ping);
+};

--- a/test/fixtures/apps/socket.io-generateId/config/config.default.js
+++ b/test/fixtures/apps/socket.io-generateId/config/config.default.js
@@ -1,0 +1,9 @@
+'use strict';
+
+exports.io = {
+    generateId: (request) => {
+        return 'This should be a random unique ID';
+    }
+};
+
+exports.keys = '123';

--- a/test/fixtures/apps/socket.io-generateId/package.json
+++ b/test/fixtures/apps/socket.io-generateId/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "socket.io-generateId",
+  "version": "0.0.1"
+}


### PR DESCRIPTION
Ref: 
1) https://github.com/eggjs/egg/issues/2850,
2) https://github.com/eggjs/egg/issues/2878,
3) https://github.com/eggjs/egg-socket.io/pull/42

Considering there're more than one requiring for this feature, we
think we can add this by exposing this interface.

PS：Remove the version check in the unit test, because we don't need this (Our node MUST BE >= 8.x).