### PR TITLE
doc (README.md/README-zh_CN.md): Add clarification

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,9 +65,9 @@ exports.io = {
 
 #### uws
 
-**Note:** `uws` has been deprecated, please find another reliable library instead.
+**Note: `uws` isn't supported in Nodejs 10.x or later version by experiment, and it has been deprecated, please find another reliable library instead.**
 
-If you want to replace the default `ws` with [uws](https://github.com/uWebSockets/uWebSockets), you can config like this:
+If you insist using [uws](https://www.npmjs.com/package/uws) instead of the default `ws`, you can config like this:
 
 ```js
 exports.io = {

--- a/README.zh_CN.md
+++ b/README.zh_CN.md
@@ -65,9 +65,9 @@ exports.io = {
 
 #### uws
 
-**注意:** `uws` 已经被官方弃用，请寻找其他可靠的替代库。
+**注意：目前实测发现 `uws` 在 Nodejs 10.x 及其后续版本中不再被支持；且 `uws` 已经被官方弃用，请寻找其他可靠的替代库。**
 
-如果你想用 [uws](https://github.com/uWebSockets/uWebSockets) 替换掉默认的 `us` , 可以这样配置:
+如坚持使用 [uws](https://www.npmjs.com/package/uws) 替换掉默认的 `ws` , 可以这样配置:
 
 ```js
 exports.io = {


### PR DESCRIPTION
1) Due to `uws` isn't supported since Nodejs 10.x, so we should mention
it by bolding the words to tell the users to avoid using `uws` directly
in Nodejs 10.x or later version.

2) Change the uws's url, because this lib is duplicated, and we have to
refer the npm url as the replacer. The deprecated uws SHOUDN'T have
GitHub repository (See: https://www.npmjs.com/package/uws).