### PR TITLE
fix (index.d.ts): 'of' missing 'route' with unit tests

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -14,46 +14,49 @@
  * ```
  */
 
-import { Socket, Server } from 'socket.io';
+import { Socket, Server as SocketServer, Namespace as SocketNameSpace } from 'socket.io';
 
 declare module 'egg' {
   export interface Application {
-    io: Server & Namespace & EggSocketIO;
+    io: EggIOServer & EggSocketNameSpace & EggSocketIO;
   }
 
   export interface Context {
     socket: Socket
   }
-
-  interface Namespace {
+  interface EggSocketNameSpace extends SocketNameSpace {
     // Forward the event to the Controller
     route(event: string, handler: Function): any
   }
 
+  // Because SocketIO's Server's of's interface
+  // doesn't have 'route'. So we must rewrite it
+  interface EggIOServer extends SocketServer {
+    of(nsp: string): EggSocketNameSpace;
+  }
   interface EggSocketIO {
     middleware: CustomMiddleware;
     controller: CustomController;
   }
 
-    /**
-   * your own Middleware
-   *
-   * @example
-   * ```bash
-   * {
-   *    chat: Chat
-   * }
-   * ```
-   */
+  /**
+ * your own Middleware
+ *
+ * @example
+ *```bash
+ * {
+ *    auth: auth;
+ *    filter: filter;
+ * }
+ * ```
+ */
   interface CustomMiddleware { }
 
   /**
    * your own Controler
-   *
-   *```bash
+   * ```bash
    * {
-   *    auth: auth;
-   *    filter: filter;
+   *    chat: Chat
    * }
    * ```
    */

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
   },
   "devDependencies": {
     "@types/socket.io": "^1.4.33",
+    "@types/node": "^10.9.4",
+    "typescript": "^3.0.3",
     "autod": "^3.0.1",
     "egg": "^2.6.1",
     "egg-bin": "^4.3.7",
@@ -38,7 +40,7 @@
     "webstorm-disable-index": "^1.2.0"
   },
   "engines": {
-    "node": ">=6.0.0"
+    "node": ">=8.0.0"
   },
   "scripts": {
     "test": "npm run lint -- --fix && npm run test-local",

--- a/test/fixtures/apps/ts/socket.io-common/app/io/controller/chat.ts
+++ b/test/fixtures/apps/ts/socket.io-common/app/io/controller/chat.ts
@@ -1,0 +1,20 @@
+'use strict';
+import { Controller } from 'egg';
+
+declare module 'egg' {
+  interface CustomController {
+    chat: ChatController
+  }
+}
+
+class ChatController extends Controller {
+  async ping() {
+    const fromService = await this.ctx.service.chatservice.chatting();
+    this.ctx.socket.emit('res', fromService);
+  }
+  async namespacedPing() {
+    await this.ctx.socket.emit('res', 'tsHello!');
+  }
+}
+
+export = ChatController;

--- a/test/fixtures/apps/ts/socket.io-common/app/io/middleware/middleware.ts
+++ b/test/fixtures/apps/ts/socket.io-common/app/io/middleware/middleware.ts
@@ -1,0 +1,7 @@
+import { Context } from 'egg';
+
+module.exports = () => {
+    return async (ctx: Context) => {
+        ctx.socket.emit('onBefore', 'Before happens!');
+    };
+};

--- a/test/fixtures/apps/ts/socket.io-common/app/io/middleware/packetware.ts
+++ b/test/fixtures/apps/ts/socket.io-common/app/io/middleware/packetware.ts
@@ -1,0 +1,8 @@
+import { Context } from 'egg';
+
+module.exports = () => {
+    return async (ctx: Context, next: Function) => {
+        await next();
+        ctx.socket.emit('onAfter', 'After happens!');
+    };
+};

--- a/test/fixtures/apps/ts/socket.io-common/app/router.ts
+++ b/test/fixtures/apps/ts/socket.io-common/app/router.ts
@@ -1,0 +1,7 @@
+'use strict';
+import { Application } from 'egg';
+
+module.exports = (app: Application) => {
+  app.io.route('chat', app.io.controller.chat.ping);
+  app.io.of('ts_of').route('chat', app.io.controller.chat.namespacedPing);
+};

--- a/test/fixtures/apps/ts/socket.io-common/app/service/chatservice.ts
+++ b/test/fixtures/apps/ts/socket.io-common/app/service/chatservice.ts
@@ -1,0 +1,14 @@
+import { Service } from "egg";
+
+declare module 'egg' {
+    interface IService {
+        chatservice: ChatService;
+    }
+}
+class ChatService extends Service {
+    async chatting() {
+        return 'from chatting service';
+    }
+}
+
+export = ChatService;

--- a/test/fixtures/apps/ts/socket.io-common/config/config.default.js
+++ b/test/fixtures/apps/ts/socket.io-common/config/config.default.js
@@ -1,0 +1,13 @@
+'use strict';
+
+exports.io = {
+  namespace: {
+    '/': {
+      connectionMiddleware: ['middleware'],
+      packetMiddleware: ['packetware'],
+    },
+    'ts_of': {}
+  }
+};
+
+exports.keys = '123';

--- a/test/fixtures/apps/ts/socket.io-common/package.json
+++ b/test/fixtures/apps/ts/socket.io-common/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "socket.io-test",
+  "version": "0.0.1"
+}

--- a/test/fixtures/apps/ts/tsconfig.json
+++ b/test/fixtures/apps/ts/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "es2017",
+    "module": "commonjs",
+    "baseUrl": ".",
+    "strict": true,
+    "lib": [
+      "es2017"
+    ],
+    "skipLibCheck": true
+  },
+  "include": [
+    "../../../../**/*"
+  ]
+}


### PR DESCRIPTION
1) 'of' has missed the method of 'route', and this should be a method
of egg-socket itself. So add it (See: https://github.com/eggjs/egg-socket.io/pull/37#issuecomment-384183665).

2) Add a whole missing tests including a full example of namespaced,
packagemiddlewares, controllmiddlewares...ect to run with ts.