### PR TITLE
Upgrade socket.io to version 4.7.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "delegates": "^1.0.0",
     "is-type-of": "^1.2.1",
     "koa-compose": "^4.1.0",
-    "socket.io": "^2.1.1",
+    "socket.io": "^4.7.5",
     "socket.io-redis": "^5.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
解决openSCA扫描的egg-socket.io相关间接依赖版本漏洞问题
![微信图片_20240603094656](https://github.com/eggjs/egg-socket.io/assets/167730099/43082339-fb36-40ee-94ca-bd2075ff27c7)

1. socket.io-parser：[egg-socket.io:4.1.6]/[socket.io:2.5.0]/[socket.io-client:2.5.0]/[socket.io-parser:3.3.3]]
2. engine.io：[egg-socket.io:4.1.6]/[socket.io:2.5.0]/[engine.io:3.6.1]]
3. debug： [egg-socket.io:4.1.6]/[socket.io:2.5.0]/[debug:4.1.1]]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated `socket.io` dependency from version `^2.1.1` to `^4.7.5` for improved performance and security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->